### PR TITLE
Fix blog articles not loading

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react"
-import { getLatestPosts } from "@/lib/wp"
+import { getAllPosts } from "@/lib/graphql-api"
 import { BlogPageClient } from "@/components/blog-page-client"
 import { Skeleton } from "@/components/ui/skeleton"
 
@@ -43,15 +43,15 @@ function BlogSkeleton() {
 async function BlogPageContent() {
   try {
     console.log("🚀 BlogPageContent: Iniziando caricamento posts...")
-    const posts = await getLatestPosts(12)
+    const { posts, hasNextPage, endCursor } = await getAllPosts(12)
     console.log("✅ BlogPageContent: Posts caricati con successo:", posts.length)
 
     // Passa i dati al Client Component
     return (
       <BlogPageClient 
         initialPosts={posts} 
-        hasNextPage={false} 
-        endCursor={null}
+        hasNextPage={hasNextPage} 
+        endCursor={endCursor}
       />
     )
   } catch (error) {

--- a/components/blog-card.tsx
+++ b/components/blog-card.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link"
-import type { WPPost } from "@/lib/wp"
+import type { BlogPost } from "@/lib/graphql-api"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 
 interface BlogCardProps {
-  post: WPPost
+  post: BlogPost
 }
 
 export function BlogCard({ post }: BlogCardProps) {

--- a/components/blog-list.tsx
+++ b/components/blog-list.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import { useState } from "react"
-import type { WPPost } from "@/lib/wp"
+import type { BlogPost } from "@/lib/graphql-api"
 import { BlogCard } from "./blog-card"
 import { Button } from "@/components/ui/button"
 import { fetchGraphQLWithRetry } from "@/lib/fetch-with-retry"
 
 interface BlogListProps {
-  initialPosts: WPPost[]
+  initialPosts: BlogPost[]
   hasNextPage: boolean
   endCursor: string | null
 }
@@ -71,16 +71,16 @@ export function BlogList({
       }
       
       // Sort new posts by date (most recent first)
-      const newPosts = data.posts.nodes.sort((a: WPPost, b: WPPost) => {
+      const newPosts = data.posts.nodes.sort((a: BlogPost, b: BlogPost) => {
         return new Date(b.date).getTime() - new Date(a.date).getTime()
       })
       
       console.log(`✅ BlogList: Caricati ${newPosts.length} nuovi posts`)
       
-      setPosts((prevPosts: WPPost[]) => {
+      setPosts((prevPosts: BlogPost[]) => {
         const combined = [...prevPosts, ...newPosts]
         // Re-sort the entire array to maintain order
-        return combined.sort((a: WPPost, b: WPPost) => {
+        return combined.sort((a: BlogPost, b: BlogPost) => {
           return new Date(b.date).getTime() - new Date(a.date).getTime()
         })
       })

--- a/components/blog-page-client.tsx
+++ b/components/blog-page-client.tsx
@@ -1,11 +1,11 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import type { WPPost } from "@/lib/wp"
+import type { BlogPost } from "@/lib/graphql-api"
 import { BlogList } from "./blog-list"
 
 interface BlogPageClientProps {
-  initialPosts: WPPost[]
+  initialPosts: BlogPost[]
   hasNextPage: boolean
   endCursor: string | null
   error?: string


### PR DESCRIPTION
Unify blog post fetching by migrating the main blog page to use the new GraphQL API.

The main blog page was using an outdated `getLatestPosts` function from `/lib/wp.ts`, while individual post pages were already using the more robust `getAllPosts` from `/lib/graphql-api.ts`. This inconsistency caused the blog to display "no articles available". This PR updates the main blog page and related components to consistently use the new GraphQL API, ensuring proper post loading and pagination.

---
<a href="https://cursor.com/background-agent?bcId=bc-88d8be6e-1b54-4a09-ae84-579330ef611e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88d8be6e-1b54-4a09-ae84-579330ef611e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

